### PR TITLE
disable strict host checking with a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.24.0] - 29-09-2022
 Disable strict host checking using the global flag `--disable-strict-host-check` or `-d`. 
-This is only intended ot be used on CI where known_hosts is not cached. 
+This is only intended to be used on CI where known_hosts is not cached. 
 
 ## [0.23.0] - 14-03-2022
 `vergo get cv` should return `0.0.0-SNAPSHOT` in an empty repo or a repo without any tags 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.24.0] - 29-09-2022
+Disable strict host checking using the global flag `--disable-strict-host-check` or `-d`. 
+This is only intended ot be used on CI where known_hosts is not cached. 
+
 ## [0.23.0] - 14-03-2022
 `vergo get cv` should return `0.0.0-SNAPSHOT` in an empty repo or a repo without any tags 
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ go install github.com/sky-uk/vergo@latest
     vergo bump auto -t app #will look for patch/minor/major in commit message
   ```
 
+## Strict Host Checking
+
+You can address the error `ssh: handshake failed: knownhosts: key is unknown ` when pushing tags with vergo in two ways:
+- Calling `ssh-keyscan -H github.com >> ~/.ssh/known_hosts` prior to pushing your vergo tag to introduce github to your known hosts.
+- Calling `vergo` with the `--disable-strict-host-check` flag. This should only be used on CI where known hosts are not cached.
+
 ## Contributions
 
 We welcome contributions to Vergo. Please see [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to contribute.

--- a/cmd/cmd_bump.go
+++ b/cmd/cmd_bump.go
@@ -47,7 +47,7 @@ func BumpCmd(bumpFunc bump.Func, pushTag vergo.PushTagFunc) *cobra.Command {
 				return err
 			}
 			if pushTagParam {
-				err = pushTag(repo, version.String(), rootFlags.tagPrefix, rootFlags.remote, rootFlags.dryRun)
+				err = pushTag(repo, version.String(), rootFlags.tagPrefix, rootFlags.remote, rootFlags.dryRun, rootFlags.disableStrictHostChecking)
 				if err != nil {
 					return err
 				}

--- a/cmd/cmd_consts.go
+++ b/cmd/cmd_consts.go
@@ -6,6 +6,7 @@ const dryRun = "dry-run"
 const tagPrefix = "tag-prefix"
 const logLevel = "log-level"
 const remoteName = "remote-name"
+const strictHostChecking = "disable-strict-host-check"
 
 const pushTagParam = "push-tag"
 const mergeCommits = "merge-commits"

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -24,7 +24,7 @@ func PushCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			err = vergo.PushTag(repo, ref.Version.String(), rootFlags.tagPrefix, rootFlags.remote, rootFlags.dryRun)
+			err = vergo.PushTag(repo, ref.Version.String(), rootFlags.tagPrefix, rootFlags.remote, rootFlags.dryRun, rootFlags.disableStrictHostChecking)
 			if err != nil {
 				return err
 			}

--- a/fun-tests/test.sh
+++ b/fun-tests/test.sh
@@ -111,6 +111,14 @@ readonly tagPrefixBananaVersion_2_0_0="$(vergo bump major --push-tag --tag-prefi
 [[ "$(vergo get lr --tag-prefix=banana)" == "2.0.0" ]]
 [[ "$(vergo get cv --tag-prefix=banana)" == "2.0.0" ]]
 
+#test bump major ignoring strict host checking
+readonly tagPrefixBananaVersion_3_0_0="$(vergo bump minor --push-tag --tag-prefix=mango --log-level=trace -d 2>&1)"
+[[ $tagPrefixBananaVersion_3_0_0 == *'Set tag mango-0.1.0'* ]]
+[[ $tagPrefixBananaVersion_3_0_0 == *'Pushing tag: mango-0.1.0'* ]]
+#test bump major check version with strict host checking
+[[ "$(vergo get lr --tag-prefix=mango)" == "0.1.0" ]]
+[[ "$(vergo get cv --tag-prefix=mango)" == "0.1.0" ]]
+
 #test bump major with slash postfix
 readonly tagPrefixOrangeVersion_3_0_0="$(vergo bump major --push-tag --tag-prefix=orange/v --log-level=trace 2>&1)"
 [[ $tagPrefixOrangeVersion_3_0_0 == *'Set tag orange/v3.0.0'* ]]

--- a/git/git.go
+++ b/git/git.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/vergo/release"
+	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	"net"
 	"os"
@@ -110,9 +111,9 @@ func CreateTag(repo *gogit.Repository, version, prefix string, dryRun bool) erro
 type PushTagFunc func(
 	repo *gogit.Repository,
 	version, prefix, remote string,
-	dryRun bool) error
+	dryRun bool, disableStrictHostChecking bool) error
 
-func PushTag(r *gogit.Repository, version, prefix, remote string, dryRun bool) error {
+func PushTag(r *gogit.Repository, version, prefix, remote string, dryRun bool, disableStrictHostChecking bool) error {
 	tag := prefix + version
 
 	socket, found := os.LookupEnv("SSH_AUTH_SOCK")
@@ -138,6 +139,10 @@ func PushTag(r *gogit.Repository, version, prefix, remote string, dryRun bool) e
 	auth := &ssh.PublicKeys{
 		User:   "git",
 		Signer: signers[0],
+	}
+
+	if disableStrictHostChecking {
+		auth.HostKeyCallback = cryptossh.InsecureIgnoreHostKey()
 	}
 
 	log.Debugf("Pushing tag: %v", tag)


### PR DESCRIPTION
When running vergo on CI (and locally without github as an entry to known_hosts) we were getting the error:

```
INFO[0000] push to remote origin error: ssh: handshake failed: knownhosts: key is unknown 
```

This can be fixed by running the command:
`ssh-keyscan -H github.com >> ~/.ssh/known_hosts`

There should be no need to run this on CI as this is not cached, therefore this PR adds a new flag to disable strict host checking with the suggetion to only using this on CI.