### PR TITLE
[vergo:minor-release] add bin to gitignore for goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
 dist/
 .idea/
+bin/


### PR DESCRIPTION
```
0.25.0   • releasing...
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=fc783c03b125fc1a24acee0670e3a0e0599c8020 latest tag=v0.25.0
   ⨯ release failed after 0.07s error=git is currently in a dirty state, please check in your pipeline what can be changing the following files:
?? bin/
```