### PR TITLE
Fix bug in tag prefix trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.26.0] - 15-11-2022
+Fixed bug in tag prefix trimming.
+
 ## [0.24.0] - 29-09-2022
 Disable strict host checking using the global flag `--disable-strict-host-check` or `-d`. 
 This is only intended to be used on CI where known_hosts is not cached. 

--- a/git/git.go
+++ b/git/git.go
@@ -3,6 +3,12 @@ package git
 import (
 	"errors"
 	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -10,14 +16,10 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	log "github.com/sirupsen/logrus"
-	"github.com/sky-uk/vergo/release"
 	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"net"
-	"os"
-	"regexp"
-	"sort"
-	"strings"
+
+	"github.com/sky-uk/vergo/release"
 )
 
 type SortDirection string
@@ -248,7 +250,7 @@ func refsWithPrefix(repo *gogit.Repository, prefix string) ([]SemverRef, error) 
 	err = tagRefs.ForEach(func(t *plumbing.Reference) error {
 		tag := t.Name().String()
 		if re.MatchString(tag) {
-			versionString := strings.TrimLeft(tag, tagPrefix)
+			versionString := strings.TrimPrefix(tag, tagPrefix)
 			if version, err := semver.NewVersion(versionString); err == nil {
 				versions = append(versions, SemverRef{Version: version, Ref: t})
 			} else {

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -3,20 +3,22 @@ package git_test
 import (
 	"errors"
 	"fmt"
+	"math"
+	"testing"
+	"time"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/stretchr/testify/assert"
+	"github.com/thoas/go-funk"
+	"go.uber.org/atomic"
+
 	"github.com/sky-uk/vergo/bump"
 	. "github.com/sky-uk/vergo/git"
 	. "github.com/sky-uk/vergo/internal-test"
 	"github.com/sky-uk/vergo/release"
-	"github.com/stretchr/testify/assert"
-	"github.com/thoas/go-funk"
-	"go.uber.org/atomic"
-	"math"
-	"testing"
-	"time"
 )
 
 var (
@@ -234,7 +236,7 @@ func TestFindLatestTagSameCommitWithPrefix(t *testing.T) {
 				for patch := 1; patch < 5; patch++ {
 					versionSuffix := fmt.Sprintf("%d.%d.%d", major, minor, patch)
 					t.Run(versionSuffix, func(t *testing.T) {
-						tagPrefix1 := "app" + postfix
+						tagPrefix1 := "app1" + postfix
 						version1 := fmt.Sprintf("%d.%d.%d", major, minor, patch)
 						tag1 := fmt.Sprintf("%s%s", tagPrefix1, version1)
 						ref1 := r.CreateTag(tag1, r.Head().Hash())


### PR DESCRIPTION
The tag prefix trimming was using `strings.TrimLeft`, which gave an incorrect result if the tag prefix happened to contain a digit that was also in the version number.

For example: `myapp1-1.0.0` would be trimmed to `.0.0` rather than `1.0.0`.

The correct function to use in this case is `strings.TrimPrefix`.

Fixes #9