### PR TITLE
[vergo:minor-release] Look for head commit at any point of versioned branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.27.0] - 08-02-2023
+Fixed bug introduced in version `0.21.0` where `vergo bump` and `vergo check` would fail if the current commit is not 
+the latest on a versioned branch e.g. `master` or `main`.
+
 ## [0.26.0] - 15-11-2022
 Fixed bug in tag prefix trimming.
 

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -1,6 +1,7 @@
 package bump_test
 
 import (
+	"fmt"
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-git/go-billy/v5/memfs"
 	gogit "github.com/go-git/go-git/v5"
@@ -115,7 +116,7 @@ func TestBumpShouldFailWhenNotOnMainBranch(t *testing.T) {
 				r.BranchExists(branchName)
 				assert.Equal(t, branchName, r.Head().Name().Short())
 				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
-				assert.Regexp(t, "branch apple is not in main branches list: master, main", err)
+				assert.Regexp(t, "branch apple is not in versioned branches list: master, main", err)
 			})
 		}
 	}
@@ -161,7 +162,7 @@ func TestBumpShouldNOTWorkWhenHeadlessCheckoutOfOtherBranch(t *testing.T) {
 				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
 
 				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
-				assert.Regexp(t, "invalid headless checkout", err)
+				assert.Equal(t, fmt.Sprintf("commit %s is not on a versioned branch: master, main", latestHashOnApple.String()), err.Error())
 			})
 		}
 	}

--- a/cmd/cmd_check_test.go
+++ b/cmd/cmd_check_test.go
@@ -1,6 +1,7 @@
 package cmd_test
 
 import (
+	"fmt"
 	. "github.com/sky-uk/vergo/internal-test"
 	"github.com/sky-uk/vergo/release"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,8 @@ func TestCheckIncrementHintSuccess(t *testing.T) {
 
 func TestCheckIncrementHintSkipHint(t *testing.T) {
 	_, tempDir := PersistentRepository(t)
-	cmd, buffer := makeCheckFail(t, release.ErrSkipRelease, release.ErrInvalidHeadless, release.ErrNoIncrement)
+	expectedError := fmt.Errorf("commit %s is not on a versioned branch: %s", "blah", "blah")
+	cmd, buffer := makeCheckFail(t, release.ErrSkipRelease, expectedError, release.ErrNoIncrement)
 	cmd.SetArgs([]string{"check", "increment-hint", "--repository-location", tempDir, "-t", "some-prefix", "--log-level", "error"})
 	err := cmd.Execute()
 	assert.Nil(t, err)
@@ -54,20 +56,22 @@ func TestCheckIncrementHintFailure(t *testing.T) {
 
 func TestCheckReleaseManyFailures(t *testing.T) {
 	_, tempDir := PersistentRepository(t)
-	cmd, buffer := makeCheckFail(t, release.ErrSkipRelease, release.ErrInvalidHeadless, success)
+	expectedError := fmt.Errorf("commit %s is not on a versioned branch: %s", "blah", "blah")
+	cmd, buffer := makeCheckFail(t, release.ErrSkipRelease, expectedError, success)
 	cmd.SetArgs([]string{"check", "release", "--repository-location", tempDir, "-t", "some-prefix", "--log-level", "error"})
 	err := cmd.Execute()
 	assert.NotNil(t, err)
 	assert.Equal(t, `Error: skip release hint present
-HEAD validation: invalid headless checkout
+commit blah is not on a versioned branch: blah
 `, readBuffer(t, buffer))
 }
 
 func TestCheckReleaseInvalidHeadless(t *testing.T) {
 	_, tempDir := PersistentRepository(t)
-	cmd, buffer := makeCheckFail(t, success, release.ErrInvalidHeadless, success)
+	expectedError := fmt.Errorf("commit %s is not on a versioned branch: %s", "blah", "blah")
+	cmd, buffer := makeCheckFail(t, success, expectedError, success)
 	cmd.SetArgs([]string{"check", "release", "--repository-location", tempDir, "-t", "some-prefix", "--log-level", "error"})
 	err := cmd.Execute()
 	assert.NotNil(t, err)
-	assert.Equal(t, "Error: HEAD validation: invalid headless checkout\n", readBuffer(t, buffer))
+	assert.Equal(t, "Error: commit blah is not on a versioned branch: blah\n", readBuffer(t, buffer))
 }

--- a/fun-tests/test.sh
+++ b/fun-tests/test.sh
@@ -175,8 +175,8 @@ setUpLikeCI
 
 [[ "$(git branch -l | grep -v HEAD)" == "" ]] #make sure no local branch
 git checkout d13ae40 #commit on the `test-branch` branch
-[[ "$(vergo check release --tag-prefix=apple 2>&1)" == *'invalid headless checkout'* ]]
-[[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *'invalid headless checkout'* ]]
+[[ "$(vergo check release --tag-prefix=apple 2>&1)" == *' is not on a versioned branch'* ]]
+[[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *' is not on a versioned branch'* ]]
 
 [[ "$(git branch -l | grep -v HEAD)" == "" ]] #make sure no local branch
 git checkout a54f1f7
@@ -184,5 +184,5 @@ vergo check release --tag-prefix=apple
 [[ "$(vergo bump minor --tag-prefix=apple --log-level=trace 2>&1)" == *'Set tag apple-0.2.0'* ]]
 
 git checkout origin/master -b master #create local branch
-[[ "$(vergo check release --tag-prefix=apple --log-level=trace --versioned-branch-names main 2>&1)" == *'branch master is not in main branches list: main'* ]]
-[[ "$(vergo bump minor --tag-prefix=apple --log-level=trace --versioned-branch-names main 2>&1)" == *'branch master is not in main branches list: main'* ]]
+[[ "$(vergo check release --tag-prefix=apple --log-level=trace --versioned-branch-names main 2>&1)" == *'branch master is not in versioned branches list: main'* ]]
+[[ "$(vergo bump minor --tag-prefix=apple --log-level=trace --versioned-branch-names main 2>&1)" == *'branch master is not in versioned branches list: main'* ]]

--- a/fun-tests/test.sh
+++ b/fun-tests/test.sh
@@ -174,7 +174,7 @@ remote_tags=$(git ls-remote --tags origin apple-0.2.0 app-0.1.1 banana-2.0.0 ora
 setUpLikeCI
 
 [[ "$(git branch -l | grep -v HEAD)" == "" ]] #make sure no local branch
-git checkout 117443bb
+git checkout d13ae40 #commit on the `test-branch` branch
 [[ "$(vergo check release --tag-prefix=apple 2>&1)" == *'invalid headless checkout'* ]]
 [[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *'invalid headless checkout'* ]]
 

--- a/release/release.go
+++ b/release/release.go
@@ -102,13 +102,13 @@ func ValidateHEAD(repo *gogit.Repository, remoteName string, versionedBranches [
 			if err != nil {
 				log.WithError(err).Debugf("branchRef could not be resolved: %s\n", branchRef.String())
 			} else {
-				commitOnBranch, err := isCommitOnBranch(repo, head.Hash(), branchRef)
+				commitOnVersionedBranch, err := isCommitOnBranch(repo, head.Hash(), branchRef)
 				if err != nil {
 					log.WithError(err).Errorf("Failed to check if commit %s is on branch %s\n",
 						head.Hash().String(), branchRef.String())
 				}
 
-				if commitOnBranch {
+				if commitOnVersionedBranch {
 					validRef = true
 					break
 				} else {

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -1,6 +1,7 @@
 package release_test
 
 import (
+	"fmt"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	. "github.com/sky-uk/vergo/internal-test"
@@ -157,7 +158,7 @@ func TestShouldFailWhenNotOnMainBranch(t *testing.T) {
 				r.BranchExists(branchName)
 				assert.Equal(t, branchName, r.Head().Name().Short())
 				err = release.ValidateHEAD(r.Repo, remoteName, mainBranch)
-				assert.Regexp(t, "branch apple is not in main branches list: master, main", err)
+				assert.Regexp(t, "branch apple is not in versioned branches list: master, main", err)
 			})
 		}
 	}
@@ -222,7 +223,7 @@ func TestShouldNOTWorkWhenHeadlessCheckoutOfOtherBranch(t *testing.T) {
 				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
 
 				err = release.ValidateHEAD(r.Repo, remoteName, mainBranch)
-				assert.Regexp(t, "invalid headless checkout", err)
+				assert.Equal(t, fmt.Sprintf("commit %s is not on a versioned branch: master, main", latestHashOnApple.String()), err.Error())
 			})
 		}
 	}

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -181,6 +181,25 @@ func TestShouldWorkWhenHeadlessCheckoutOfMainBranch(t *testing.T) {
 }
 
 //nolint:scopelint,paralleltest
+func TestShouldWorkWhenOnHeadlessCheckoutOfOldCommitOnMainBranch(t *testing.T) {
+	for _, prefix := range prefixes {
+		for _, increment := range increments {
+			t.Run(prefix+"-"+increment, func(t *testing.T) {
+				r := NewTestRepo(t)
+				oldCommit := r.Head().Hash()
+				r.DoCommit("foo")
+				err := r.Worktree().Checkout(&gogit.CheckoutOptions{Hash: oldCommit})
+				assert.Nil(t, err)
+				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
+
+				err = release.ValidateHEAD(r.Repo, remoteName, mainBranch)
+				assert.Nil(t, err)
+			})
+		}
+	}
+}
+
+//nolint:scopelint,paralleltest
 func TestShouldNOTWorkWhenHeadlessCheckoutOfOtherBranch(t *testing.T) {
 	for _, prefix := range prefixes {
 		for _, increment := range increments {


### PR DESCRIPTION
- This is an attempt to fix #13, using code shamelessly stolen from https://github.com/src-d/go-git/issues/611#issuecomment-334476754
- This allows vergo to release on older commits that live on the versioned branches e.g. `master` and `main` (by default)

Required by #13
