### PR TITLE
[vergo:minor-release] Use Bearer auth if presented with the GITHUB_TOKEN env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.28.0] - 09-04-2024
+Prefers to use the GITHUB_TOKEN Bearer authentication over SSH if the environment variable is present.
+This is useful when pushing tags using GitHub actions.
+
 ## [0.27.0] - 08-02-2023
 Fixed bug introduced in version `0.21.0` where `vergo bump` and `vergo check` would fail if the current commit is not 
 the latest on a versioned branch e.g. `master` or `main`.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@
 export
 
 GORELEASER_VERSION := 0.179.0
-LINTER_VERSION := 1.46.2
+LINTER_VERSION := 1.53.3
 PATH := $(shell pwd)/bin:$(PATH)
 SHELL := bash
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ You can address the error `ssh: handshake failed: knownhosts: key is unknown ` w
 - Calling `ssh-keyscan -H github.com >> ~/.ssh/known_hosts` prior to pushing your vergo tag to introduce github to your known hosts.
 - Calling `vergo` with the `--disable-strict-host-check` flag. This should only be used on CI where known hosts are not cached.
 
+## Using GITHUB_TOKEN inside GitHub Actions
+
+Vergo will first try to use Token Bearer Authentication using the GITHUB_TOKEN environment variable when running inside a GitHub Action/Workflow. It will fallback to ssh based authentication if the GITHUB_TOKEN is not present.
+
+Inside github actions please ensure that the GITHUB_TOKEN environment variable is set with the `${{ secrets.GITHUB_TOKEN }}` in order to push to the current repository.
+
+Please see  [token authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) for further details.
+
+The GITHUB_TOKEN will require the following permissions to be able to push:
+```yaml
+    permissions:
+      contents: write
+```
+
 ## Running Locally - SSH Key Failures
 You can address the error `FATA[0000] failed to get signers, make sure to add private key identities to the authentication agent  error="<nil>"` when pushing tags with vergo by:
 - Calling `ssh-add ~/.ssh/<github_key>` to add your github ssh key to the ssh agent

--- a/release/release.go
+++ b/release/release.go
@@ -90,7 +90,7 @@ func ValidateHEAD(repo *gogit.Repository, remoteName string, versionedBranches [
 		validRef := false
 		for _, mainBranchName := range versionedBranches {
 			remote, err := repo.Remote(remoteName)
-			if err != nil && err != gogit.ErrRemoteNotFound {
+			if err != nil && !errors.Is(err, gogit.ErrRemoteNotFound) {
 				return err
 			}
 			var branchRef plumbing.ReferenceName


### PR DESCRIPTION
Required for use of vergo in github actions pipelines.

The push logic is largely under tested. Only really covered in the `fun-test` suite. This suite currently assumes you are running from a local non automated pipeline cloned with SSH or from an agent with an ssh-agent installed.

The github-token can be tested with a PAT token, but I would rather add a different suite outside the opensource repo to fully verify end to end.

I have undergone manual testing, alongside verified existing functional tests are still valid.

```
{11:35}~/workspace/spikes/tagtest:main ✓ ➭ GITHUB_TOKEN=<> ../../core/vergo/dist/vergo_darwin_arm64/vergo -t testtag release -u -d minor
INFO[0000] Set tag testtag-0.2.0
INFO[0000] Using Github Bearer Token Auth
0.2.0%
```