### PR TITLE
[vergo:patch-release] Fix problems authenticating using GITHUB_TOKEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.29.0] - 09-05-2024
+Fixed a bug with GITHUB_TOKEN authentication where pushes would fail when configured to use a GitHub token.
+
 ## [0.28.0] - 09-04-2024
 Prefers to use the GITHUB_TOKEN Bearer authentication over SSH if the environment variable is present.
 This is useful when pushing tags using GitHub actions.

--- a/git/git.go
+++ b/git/git.go
@@ -44,7 +44,7 @@ var (
 	ErrOneTagFound          = errors.New("one tag found")
 	ErrInvalidSortDirection = errors.New("invalid sort direction")
 	ErrPreReleaseVersion    = errors.New("invalid preReleaseVersion")
-	ErrUndefinedSSHAuthSock = errors.New("SSH_AUTH_SOCK is not defined")
+	ErrUndefinedAuth        = errors.New("no auth has been configured, GITHUB_TOKEN or SSH_AUTH_SOCK must be set")
 )
 
 func ParseSortDirection(str string) (SortDirection, error) {
@@ -125,8 +125,9 @@ func PushTag(r *gogit.Repository, version, prefix, remote string, dryRun bool, d
 
 	if githubToken, ok := os.LookupEnv("GITHUB_TOKEN"); ok {
 		log.Debug("Using Github Bearer Token Auth")
-		auth = &http.TokenAuth{
-			Token: githubToken,
+		auth = &http.BasicAuth{
+			Username: "can-be-anything",
+			Password: githubToken,
 		}
 	} else if socket, ok := os.LookupEnv("SSH_AUTH_SOCK"); ok {
 		log.Debug("Using SSH Agent Authentication")
@@ -144,7 +145,7 @@ func PushTag(r *gogit.Repository, version, prefix, remote string, dryRun bool, d
 
 		auth = sshAuth
 	} else {
-		return ErrUndefinedSSHAuthSock
+		return ErrUndefinedAuth
 	}
 
 	log.Debugf("Pushing tag: %v", tag)


### PR DESCRIPTION
I have tested this change locally by using vergo to push a tag to a test repository. Using what is currently on the master branch the command fails with:
```
push to remote origin error: authentication required
```

Using the changes on this branch the tag is pushed successfully.