### PR TITLE
bump golangci-lint to work with golang 1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## [0.29.0] - 09-05-2024
+## [0.28.1] - 09-05-2024
 Fixed a bug with GITHUB_TOKEN authentication where pushes would fail when configured to use a GitHub token.
+Fixed version of golangci-lint to work with more recent golang versions.
+
 
 ## [0.28.0] - 09-04-2024
 Prefers to use the GITHUB_TOKEN Bearer authentication over SSH if the environment variable is present.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@
 export
 
 GORELEASER_VERSION := 0.179.0
-LINTER_VERSION := 1.53.3
+LINTER_VERSION := 1.58.1
 PATH := $(shell pwd)/bin:$(PATH)
 SHELL := bash
 


### PR DESCRIPTION
Update linter to work on newever versions of golang for release