### PR TITLE
[vergo:minor-release] Add axion default behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.30.0] - 13-05-2024
+Add Axion current behaviour when getting and bumping tag behind
+Add FirstTagEncountered flag to enable this new feature
+
 ## [0.29.0] - 13-05-2024
 Allows the environment variable key that is looked up to enable token based authentication to be configurable. The default is now `GH_TOKEN`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [0.30.0] - 13-05-2024
 Add Axion current behaviour when getting and bumping tag behind
-Add FirstTagEncountered flag to enable this new feature
+Add NearestRelease flag to enable this new feature
 
 ## [0.29.0] - 13-05-2024
 Allows the environment variable key that is looked up to enable token based authentication to be configurable. The default is now `GH_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ go install github.com/sky-uk/vergo@latest
 
   `vergo get current-version --tag-prefix=banana`
 
+* returns the current tag/release prefixed with banana, maybe a SNAPSHOT, using the first tag matched in the commit history 
+
+  `vergo get current-version --tag-prefix=banana --enable-first-tag-match`
+
+* increments patch part of the version prefixed with banana, using the first tag matched in the commit history
+
+  `vergo bump patch --tag-prefix=banana --enable-first-tag-match`
+
 * increments patch part of the version prefixed with banana
 
   `vergo bump patch --tag-prefix=banana`

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ go install github.com/sky-uk/vergo@latest
 
 * returns the current tag/release prefixed with banana, maybe a SNAPSHOT, using the first tag matched in the commit history 
 
-  `vergo get current-version --tag-prefix=banana --enable-first-tag-match`
+  `vergo get current-version --tag-prefix=banana --nearest-release`
 
 * increments patch part of the version prefixed with banana, using the first tag matched in the commit history
 
-  `vergo bump patch --tag-prefix=banana --enable-first-tag-match`
+  `vergo bump patch --tag-prefix=banana --nearest-release`
 
 * increments patch part of the version prefixed with banana
 

--- a/bump/bump.go
+++ b/bump/bump.go
@@ -35,10 +35,11 @@ const (
 )
 
 type Options struct {
-	TagPrefix         string
-	Remote            string
-	VersionedBranches []string
-	DryRun            bool
+	TagPrefix           string
+	Remote              string
+	VersionedBranches   []string
+	DryRun              bool
+	FirstTagEncountered bool
 }
 
 type Func func(repo *gogit.Repository, increment string, options Options) (*semver.Version, error)
@@ -52,7 +53,13 @@ func Bump(repo *gogit.Repository, increment string, options Options) (*semver.Ve
 		return nil, err
 	}
 
-	latest, err := git.LatestRef(repo, options.TagPrefix)
+	var latest git.SemverRef
+	if options.FirstTagEncountered {
+		latest, err = git.GetFirstMatchingTag(repo, options.TagPrefix)
+	} else {
+		latest, err = git.LatestRef(repo, options.TagPrefix)
+	}
+
 	if errors.Is(err, git.ErrNoTagFound) {
 		newVersion, err := semver.NewVersion(firstVersion)
 		if err != nil {

--- a/bump/bump.go
+++ b/bump/bump.go
@@ -35,11 +35,11 @@ const (
 )
 
 type Options struct {
-	TagPrefix           string
-	Remote              string
-	VersionedBranches   []string
-	DryRun              bool
-	FirstTagEncountered bool
+	TagPrefix         string
+	Remote            string
+	VersionedBranches []string
+	DryRun            bool
+	NearestRelease    bool
 }
 
 type Func func(repo *gogit.Repository, increment string, options Options) (*semver.Version, error)
@@ -54,8 +54,8 @@ func Bump(repo *gogit.Repository, increment string, options Options) (*semver.Ve
 	}
 
 	var latest git.SemverRef
-	if options.FirstTagEncountered {
-		latest, err = git.GetFirstMatchingTag(repo, options.TagPrefix)
+	if options.NearestRelease {
+		latest, err = git.NearestTag(repo, options.TagPrefix)
 	} else {
 		latest, err = git.LatestRef(repo, options.TagPrefix)
 	}

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -64,7 +64,7 @@ func TestBumpShouldFailWhenThereIsNoCommit(t *testing.T) {
 				fs := memfs.New()
 				r, err := gogit.Init(memory.NewStorage(), fs)
 				assert.Nil(t, err)
-				_, err = Bump(r, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				_, err = Bump(r, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Regexp(t, "reference not found", err)
 			})
 		}
@@ -77,7 +77,7 @@ func TestBumpShouldCreateFirstTag(t *testing.T) {
 		for _, increment := range increments {
 			t.Run(prefix+"-"+increment, func(t *testing.T) {
 				r := NewTestRepo(t)
-				newVersion, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				newVersion, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, firstVersion), newVersion)
 			})
@@ -92,11 +92,11 @@ func TestShouldBeAbleToCallBumpMultipleTimes(t *testing.T) {
 			t.Run(prefix+"-"+increment, func(t *testing.T) {
 				r := NewTestRepo(t)
 
-				firstCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				firstCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, firstVersion), firstCall)
 
-				secondCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				secondCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, firstVersion), secondCall)
 			})
@@ -115,7 +115,7 @@ func TestBumpShouldFailWhenNotOnMainBranch(t *testing.T) {
 				assert.Nil(t, err)
 				r.BranchExists(branchName)
 				assert.Equal(t, branchName, r.Head().Name().Short())
-				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Regexp(t, "branch apple is not in versioned branches list: master, main", err)
 			})
 		}
@@ -132,7 +132,7 @@ func TestBumpShouldWorkWhenHeadlessCheckoutOfMainBranch(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
 
-				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 			})
 		}
@@ -161,13 +161,18 @@ func TestBumpShouldNOTWorkWhenHeadlessCheckoutOfOtherBranch(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
 
-				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Equal(t, fmt.Sprintf("commit %s is not on a versioned branch: master, main", latestHashOnApple.String()), err.Error())
 			})
 		}
 	}
 }
 
+// Bumping with annotated tags is not possible under the current implementation, why test it?
+// This fails with FirstTagEncountered as true because the tag reference is not the same as the commit reference
+// A new ref is generated when its annotated
+// Setting FirstTagEncountered to false to avoid failing the test
+//
 //nolint:scopelint,paralleltest
 func TestBumpWithAnnotatedTags(t *testing.T) {
 	for _, prefix := range prefixes {
@@ -182,7 +187,7 @@ func TestBumpWithAnnotatedTags(t *testing.T) {
 			assert.Nil(t, err)
 
 			{
-				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "0.0.1"), tag)
 			}
@@ -190,17 +195,60 @@ func TestBumpWithAnnotatedTags(t *testing.T) {
 			r.DoCommit("foo")
 			assert.Nil(t, CreateTag(r.Repo, "1.0.0", prefix, false))
 			{
-				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "1.0.0"), tag)
 			}
 
 			r.DoCommit("bar")
 			{
-				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch})
+				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "1.0.1"), tag)
 			}
+		})
+	}
+}
+
+//nolint:scopelint,paralleltest
+func TestBumpWithCheckoutNewBranchWithUntaggedCommitInHotFixBranch(t *testing.T) {
+	for _, prefix := range prefixes {
+		t.Run(prefix, func(t *testing.T) {
+			r := NewTestRepo(t)
+			// Create initial tag 0.1.0
+			assert.NoError(t, CreateTag(r.Repo, "0.1.0", prefix, false))
+			initialTag := r.Head().Hash()
+
+			// Create subsequent tags 0.2.0 and 0.3.0
+			r.DoCommit("bar")
+			assert.NoError(t, CreateTag(r.Repo, "0.2.0", prefix, false))
+
+			r.DoCommit("foo")
+			assert.NoError(t, CreateTag(r.Repo, "0.3.0", prefix, false))
+
+			// Checkout to the initial tag and create a new branch hotFix
+			wt, err := r.Repo.Worktree()
+			assert.NoError(t, err)
+
+			// Checkout to specific commit hash
+			assert.NoError(t, wt.Checkout(&gogit.CheckoutOptions{Hash: initialTag}))
+
+			// Create and checkout new branch
+			assert.NoError(t, wt.Checkout(&gogit.CheckoutOptions{Branch: plumbing.NewBranchReferenceName("hotFix"), Create: true}))
+			assert.True(t, r.BranchExists("hotFix"))
+			assert.Equal(t, "hotFix", r.Head().Name().Short())
+
+			// Commit untagged changes in hotFix branch
+			r.DoCommit("untaggedCommit")
+
+			// Bump version in hotFix branch and validate
+			tag, err := Bump(r.Repo, "patch", Options{
+				TagPrefix:           prefix,
+				VersionedBranches:   []string{"master", "main", "hotFix"},
+				FirstTagEncountered: true,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, NewVersionT(t, "0.1.1"), tag)
 		})
 	}
 }
@@ -238,8 +286,7 @@ func TestBumpAllIncrements(t *testing.T) {
 				r := NewTestRepo(t)
 				r.CreateTag(prefix+version.pre.String(), r.Head().Hash())
 				r.DoCommit("bar")
-
-				tag, err := Bump(r.Repo, version.increment, Options{TagPrefix: prefix, VersionedBranches: version.versionedBranches})
+				tag, err := Bump(r.Repo, version.increment, Options{TagPrefix: prefix, VersionedBranches: version.versionedBranches, FirstTagEncountered: false})
 				assert.Nil(t, err)
 				assert.Equal(t, *version.post, *tag)
 			})

--- a/bump/bump_test.go
+++ b/bump/bump_test.go
@@ -64,7 +64,7 @@ func TestBumpShouldFailWhenThereIsNoCommit(t *testing.T) {
 				fs := memfs.New()
 				r, err := gogit.Init(memory.NewStorage(), fs)
 				assert.Nil(t, err)
-				_, err = Bump(r, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				_, err = Bump(r, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Regexp(t, "reference not found", err)
 			})
 		}
@@ -77,7 +77,7 @@ func TestBumpShouldCreateFirstTag(t *testing.T) {
 		for _, increment := range increments {
 			t.Run(prefix+"-"+increment, func(t *testing.T) {
 				r := NewTestRepo(t)
-				newVersion, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				newVersion, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, firstVersion), newVersion)
 			})
@@ -92,11 +92,11 @@ func TestShouldBeAbleToCallBumpMultipleTimes(t *testing.T) {
 			t.Run(prefix+"-"+increment, func(t *testing.T) {
 				r := NewTestRepo(t)
 
-				firstCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				firstCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, firstVersion), firstCall)
 
-				secondCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				secondCall, err := Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, firstVersion), secondCall)
 			})
@@ -115,7 +115,7 @@ func TestBumpShouldFailWhenNotOnMainBranch(t *testing.T) {
 				assert.Nil(t, err)
 				r.BranchExists(branchName)
 				assert.Equal(t, branchName, r.Head().Name().Short())
-				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Regexp(t, "branch apple is not in versioned branches list: master, main", err)
 			})
 		}
@@ -132,7 +132,7 @@ func TestBumpShouldWorkWhenHeadlessCheckoutOfMainBranch(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
 
-				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 			})
 		}
@@ -161,7 +161,7 @@ func TestBumpShouldNOTWorkWhenHeadlessCheckoutOfOtherBranch(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, plumbing.HEAD.String(), r.Head().Name().Short())
 
-				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				_, err = Bump(r.Repo, increment, Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Equal(t, fmt.Sprintf("commit %s is not on a versioned branch: master, main", latestHashOnApple.String()), err.Error())
 			})
 		}
@@ -169,9 +169,9 @@ func TestBumpShouldNOTWorkWhenHeadlessCheckoutOfOtherBranch(t *testing.T) {
 }
 
 // Bumping with annotated tags is not possible under the current implementation, why test it?
-// This fails with FirstTagEncountered as true because the tag reference is not the same as the commit reference
+// This fails with NearestRelease as true because the tag reference is not the same as the commit reference
 // A new ref is generated when its annotated
-// Setting FirstTagEncountered to false to avoid failing the test
+// Setting NearestRelease to false to avoid failing the test
 //
 //nolint:scopelint,paralleltest
 func TestBumpWithAnnotatedTags(t *testing.T) {
@@ -187,7 +187,7 @@ func TestBumpWithAnnotatedTags(t *testing.T) {
 			assert.Nil(t, err)
 
 			{
-				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "0.0.1"), tag)
 			}
@@ -195,14 +195,14 @@ func TestBumpWithAnnotatedTags(t *testing.T) {
 			r.DoCommit("foo")
 			assert.Nil(t, CreateTag(r.Repo, "1.0.0", prefix, false))
 			{
-				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "1.0.0"), tag)
 			}
 
 			r.DoCommit("bar")
 			{
-				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, FirstTagEncountered: false})
+				tag, err := Bump(r.Repo, "patch", Options{TagPrefix: prefix, VersionedBranches: mainBranch, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "1.0.1"), tag)
 			}
@@ -243,9 +243,9 @@ func TestBumpWithCheckoutNewBranchWithUntaggedCommitInHotFixBranch(t *testing.T)
 
 			// Bump version in hotFix branch and validate
 			tag, err := Bump(r.Repo, "patch", Options{
-				TagPrefix:           prefix,
-				VersionedBranches:   []string{"master", "main", "hotFix"},
-				FirstTagEncountered: true,
+				TagPrefix:         prefix,
+				VersionedBranches: []string{"master", "main", "hotFix"},
+				NearestRelease:    true,
 			})
 			assert.NoError(t, err)
 			assert.Equal(t, NewVersionT(t, "0.1.1"), tag)
@@ -286,7 +286,7 @@ func TestBumpAllIncrements(t *testing.T) {
 				r := NewTestRepo(t)
 				r.CreateTag(prefix+version.pre.String(), r.Head().Hash())
 				r.DoCommit("bar")
-				tag, err := Bump(r.Repo, version.increment, Options{TagPrefix: prefix, VersionedBranches: version.versionedBranches, FirstTagEncountered: false})
+				tag, err := Bump(r.Repo, version.increment, Options{TagPrefix: prefix, VersionedBranches: version.versionedBranches, NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, *version.post, *tag)
 			})

--- a/cmd/cmd_bump.go
+++ b/cmd/cmd_bump.go
@@ -39,11 +39,11 @@ func BumpCmd(bumpFunc bump.Func, pushTag vergo.PushTagFunc) *cobra.Command {
 				}
 			}
 			version, err := bumpFunc(repo, increment, bump.Options{
-				TagPrefix:           rootFlags.tagPrefix,
-				Remote:              rootFlags.remote,
-				VersionedBranches:   rootFlags.versionedBranches,
-				DryRun:              rootFlags.dryRun,
-				FirstTagEncountered: rootFlags.firstTagEncountered})
+				TagPrefix:         rootFlags.tagPrefix,
+				Remote:            rootFlags.remote,
+				VersionedBranches: rootFlags.versionedBranches,
+				DryRun:            rootFlags.dryRun,
+				NearestRelease:    rootFlags.nearestRelease})
 			if err != nil {
 				return err
 			}

--- a/cmd/cmd_bump.go
+++ b/cmd/cmd_bump.go
@@ -39,10 +39,11 @@ func BumpCmd(bumpFunc bump.Func, pushTag vergo.PushTagFunc) *cobra.Command {
 				}
 			}
 			version, err := bumpFunc(repo, increment, bump.Options{
-				TagPrefix:         rootFlags.tagPrefix,
-				Remote:            rootFlags.remote,
-				VersionedBranches: rootFlags.versionedBranches,
-				DryRun:            rootFlags.dryRun})
+				TagPrefix:           rootFlags.tagPrefix,
+				Remote:              rootFlags.remote,
+				VersionedBranches:   rootFlags.versionedBranches,
+				DryRun:              rootFlags.dryRun,
+				FirstTagEncountered: rootFlags.firstTagEncountered})
 			if err != nil {
 				return err
 			}

--- a/cmd/cmd_consts.go
+++ b/cmd/cmd_consts.go
@@ -3,6 +3,7 @@ package cmd
 const repositoryLocation = "repository-location"
 const versionedBranchNames = "versioned-branch-names"
 const dryRun = "dry-run"
+const firstTagEncountered = "enable-first-tag-match"
 const tagPrefix = "tag-prefix"
 const logLevel = "log-level"
 const remoteName = "remote-name"

--- a/cmd/cmd_consts.go
+++ b/cmd/cmd_consts.go
@@ -3,7 +3,7 @@ package cmd
 const repositoryLocation = "repository-location"
 const versionedBranchNames = "versioned-branch-names"
 const dryRun = "dry-run"
-const firstTagEncountered = "enable-first-tag-match"
+const nearestRelease = "nearest-release"
 const tagPrefix = "tag-prefix"
 const logLevel = "log-level"
 const remoteName = "remote-name"

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -107,7 +107,7 @@ func makeGet(t *testing.T, current vergo.CurrentVersionFunc) (*cobra.Command, *b
 		return vergo.SemverRef{Version: NewVersionT(t, "0.1.0")}, nil
 	}
 	if current == nil {
-		current = func(repo *git.Repository, prefix string, preRelease release.PreReleaseFunc) (vergo.SemverRef, error) {
+		current = func(repo *git.Repository, prefix string, preRelease release.PreReleaseFunc, _ vergo.GetOptions) (vergo.SemverRef, error) {
 			return vergo.SemverRef{Version: NewVersionT(t, "0.1.0")}, nil
 		}
 	}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -85,7 +85,7 @@ func get(latest, previous RefFunc, current vergo.CurrentVersionFunc, rootFlags *
 	case "pr", "previous-release":
 		return previous(repo, rootFlags.tagPrefix)
 	case "cv", "current-version":
-		ref, err := current(repo, rootFlags.tagPrefix, release.PreRelease(repo, release.PreReleaseOptions{WithMetadata: withMetadata}))
+		ref, err := current(repo, rootFlags.tagPrefix, release.PreRelease(repo, release.PreReleaseOptions{WithMetadata: withMetadata}), vergo.GetOptions{FirstTagEncountered: rootFlags.firstTagEncountered})
 		if errors.Is(err, plumbing.ErrReferenceNotFound) || errors.Is(err, vergo.ErrNoTagFound) {
 			return vergo.SemverRef{Version: semver.MustParse("0.0.0-SNAPSHOT")}, nil
 		}

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -85,7 +85,7 @@ func get(latest, previous RefFunc, current vergo.CurrentVersionFunc, rootFlags *
 	case "pr", "previous-release":
 		return previous(repo, rootFlags.tagPrefix)
 	case "cv", "current-version":
-		ref, err := current(repo, rootFlags.tagPrefix, release.PreRelease(repo, release.PreReleaseOptions{WithMetadata: withMetadata}), vergo.GetOptions{FirstTagEncountered: rootFlags.firstTagEncountered})
+		ref, err := current(repo, rootFlags.tagPrefix, release.PreRelease(repo, release.PreReleaseOptions{WithMetadata: withMetadata}), vergo.GetOptions{NearestRelease: rootFlags.nearestRelease})
 		if errors.Is(err, plumbing.ErrReferenceNotFound) || errors.Is(err, vergo.ErrNoTagFound) {
 			return vergo.SemverRef{Version: semver.MustParse("0.0.0-SNAPSHOT")}, nil
 		}

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -33,7 +33,7 @@ func TestGetCurrentVersionShouldReturnDefaultVersionWhenRepoIsEmpty(t *testing.T
 	args := []string{"current-version"}
 	aliases := []string{"cv"}
 	for _, arg := range append(args, aliases...) {
-		cmd, buffer := makeGet(t, func(_ *git.Repository, _ string, _ release.PreReleaseFunc) (vergo.SemverRef, error) {
+		cmd, buffer := makeGet(t, func(_ *git.Repository, _ string, _ release.PreReleaseFunc, _ vergo.GetOptions) (vergo.SemverRef, error) {
 			return vergo.EmptyRef, plumbing.ErrReferenceNotFound
 		})
 		cmd.SetArgs([]string{"get", arg, "--repository-location", tempDir, "-t", "some-prefix", "--log-level", "error"})
@@ -49,7 +49,7 @@ func TestGetCurrentVersionShouldReturnDefaultVersionWhenNoTagFound(t *testing.T)
 	args := []string{"current-version"}
 	aliases := []string{"cv"}
 	for _, arg := range append(args, aliases...) {
-		cmd, buffer := makeGet(t, func(_ *git.Repository, _ string, _ release.PreReleaseFunc) (vergo.SemverRef, error) {
+		cmd, buffer := makeGet(t, func(_ *git.Repository, _ string, _ release.PreReleaseFunc, _ vergo.GetOptions) (vergo.SemverRef, error) {
 			return vergo.EmptyRef, vergo.ErrNoTagFound
 		})
 		cmd.SetArgs([]string{"get", arg, "--repository-location", tempDir, "-t", "some-prefix", "--log-level", "error"})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP(strictHostChecking, "d", false, "disable strict host checking for git. should only be enabled on ci.")
 	rootCmd.PersistentFlags().StringP(tokenEnvVarKey, "k", "GH_TOKEN", "environment variable key to use for lookup when deciding if token based git auth should be used")
 	rootCmd.PersistentFlags().Bool(dryRun, false, "dry run")
+	rootCmd.PersistentFlags().Bool(firstTagEncountered, false, "use first tag matched in the commit history, default use highest tag")
 	rootCmd.PersistentFlags().StringSlice(versionedBranchNames, []string{"master", "main"},
 		"names of the main working branches")
 	rootCmd.PersistentFlags().BoolP(withPrefix, "p", false, "returns version with prefix")
@@ -30,11 +31,11 @@ func RootCmd() *cobra.Command {
 }
 
 type RootFlags struct {
-	remote, tagPrefix, tagPrefixRaw, repositoryLocation string
-	tokenEnvVarKey                                      string
-	logLevel                                            log.Level
-	withPrefix, dryRun, disableStrictHostChecking       bool
-	versionedBranches                                   []string
+	remote, tagPrefix, tagPrefixRaw, repositoryLocation                string
+	tokenEnvVarKey                                                     string
+	logLevel                                                           log.Level
+	withPrefix, dryRun, firstTagEncountered, disableStrictHostChecking bool
+	versionedBranches                                                  []string
 }
 
 func readRootFlags(cmd *cobra.Command) (*RootFlags, error) {
@@ -47,6 +48,10 @@ func readRootFlags(cmd *cobra.Command) (*RootFlags, error) {
 		return nil, err
 	}
 	dryRun, err := cmd.Flags().GetBool(dryRun)
+	if err != nil {
+		return nil, err
+	}
+	firstTagEncountered, err := cmd.Flags().GetBool(firstTagEncountered)
 	if err != nil {
 		return nil, err
 	}
@@ -89,6 +94,7 @@ func readRootFlags(cmd *cobra.Command) (*RootFlags, error) {
 		repositoryLocation:        repositoryLocation,
 		logLevel:                  logLevel,
 		dryRun:                    dryRun,
+		firstTagEncountered:       firstTagEncountered,
 		withPrefix:                withPrefix,
 		disableStrictHostChecking: disableStrictHostChecking,
 		tokenEnvVarKey:            tokenEnvVarKey,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ func RootCmd() *cobra.Command {
 	rootCmd.PersistentFlags().BoolP(strictHostChecking, "d", false, "disable strict host checking for git. should only be enabled on ci.")
 	rootCmd.PersistentFlags().StringP(tokenEnvVarKey, "k", "GH_TOKEN", "environment variable key to use for lookup when deciding if token based git auth should be used")
 	rootCmd.PersistentFlags().Bool(dryRun, false, "dry run")
-	rootCmd.PersistentFlags().Bool(firstTagEncountered, false, "use first tag matched in the commit history, default use highest tag")
+	rootCmd.PersistentFlags().Bool(nearestRelease, false, "use nearest tag in the commit history, default use highest tag")
 	rootCmd.PersistentFlags().StringSlice(versionedBranchNames, []string{"master", "main"},
 		"names of the main working branches")
 	rootCmd.PersistentFlags().BoolP(withPrefix, "p", false, "returns version with prefix")
@@ -31,11 +31,11 @@ func RootCmd() *cobra.Command {
 }
 
 type RootFlags struct {
-	remote, tagPrefix, tagPrefixRaw, repositoryLocation                string
-	tokenEnvVarKey                                                     string
-	logLevel                                                           log.Level
-	withPrefix, dryRun, firstTagEncountered, disableStrictHostChecking bool
-	versionedBranches                                                  []string
+	remote, tagPrefix, tagPrefixRaw, repositoryLocation           string
+	tokenEnvVarKey                                                string
+	logLevel                                                      log.Level
+	withPrefix, dryRun, nearestRelease, disableStrictHostChecking bool
+	versionedBranches                                             []string
 }
 
 func readRootFlags(cmd *cobra.Command) (*RootFlags, error) {
@@ -51,7 +51,7 @@ func readRootFlags(cmd *cobra.Command) (*RootFlags, error) {
 	if err != nil {
 		return nil, err
 	}
-	firstTagEncountered, err := cmd.Flags().GetBool(firstTagEncountered)
+	nearestRelease, err := cmd.Flags().GetBool(nearestRelease)
 	if err != nil {
 		return nil, err
 	}
@@ -94,7 +94,7 @@ func readRootFlags(cmd *cobra.Command) (*RootFlags, error) {
 		repositoryLocation:        repositoryLocation,
 		logLevel:                  logLevel,
 		dryRun:                    dryRun,
-		firstTagEncountered:       firstTagEncountered,
+		nearestRelease:            nearestRelease,
 		withPrefix:                withPrefix,
 		disableStrictHostChecking: disableStrictHostChecking,
 		tokenEnvVarKey:            tokenEnvVarKey,

--- a/fun-tests/test-bump-auto.sh
+++ b/fun-tests/test-bump-auto.sh
@@ -85,6 +85,42 @@ TestCheckIncrementWithSkipReleaseHint() (
   vergo check increment-hint --tag-prefix=apple 2>&1
 )
 
+TestBumpPatchWithNearestRelease() (
+  setup
+  mktemp "$some_temp_folder/XXXXX"
+  git add . && git commit -am"[vergo:release] a commit"
+  [[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *'0.1.0'* ]]
+
+ mktemp "$some_temp_folder/XXXXX"
+  git add . && git commit -am"[vergo:release] a commit"
+  [[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *'0.2.0'* ]]
+
+  git checkout -b hi apple-0.1.0
+  mktemp "$some_temp_folder/XXXXX"
+
+  git add . && git commit -am"[vergo:release] a commit"
+  [[ "$(vergo bump patch --nearest-release --versioned-branch-names hi --tag-prefix=apple 2>&1)" == *'0.1.1'* ]]
+
+)
+
+TestBumpPatchWithoutNearestRelease() (
+  setup
+  mktemp "$some_temp_folder/XXXXX"
+  git add . && git commit -am"[vergo:release] a commit"
+  [[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *'0.1.0'* ]]
+
+ mktemp "$some_temp_folder/XXXXX"
+  git add . && git commit -am"[vergo:release] a commit"
+  [[ "$(vergo bump minor --tag-prefix=apple 2>&1)" == *'0.2.0'* ]]
+
+  git checkout -b hi apple-0.1.0
+  mktemp "$some_temp_folder/XXXXX"
+
+  git add . && git commit -am"[vergo:release] a commit"
+  [[ "$(vergo bump patch --versioned-branch-names hi --tag-prefix=apple 2>&1)" == *'0.2.1'* ]]
+
+)
+
 tests=$(compgen -A function | grep -E '^Test')
 for fn in $tests; do
   $fn

--- a/git/git.go
+++ b/git/git.go
@@ -346,6 +346,9 @@ func CurrentVersion(repo *gogit.Repository, prefix string, preRelease release.Pr
 func NearestTag(repo *gogit.Repository, prefix string) (SemverRef, error) {
 
 	head, err := repo.Head()
+	if err != nil {
+		return EmptyRef, err
+	}
 
 	commitIter, err := repo.Log(&gogit.LogOptions{From: head.Hash()})
 	if err != nil {
@@ -371,6 +374,9 @@ func NearestTag(repo *gogit.Repository, prefix string) (SemverRef, error) {
 			}
 			return nil
 		})
+		if err != nil {
+			return err
+		}
 
 		if nearestTag != "" {
 			return storer.ErrStop
@@ -388,6 +394,9 @@ func NearestTag(repo *gogit.Repository, prefix string) (SemverRef, error) {
 
 	versionString := strings.TrimPrefix(nearestTag, prefix)
 	newVersion, err := semver.NewVersion(versionString)
+	if err != nil {
+		return EmptyRef, err
+	}
 	latest, err := SemverRef{
 		Version: newVersion,
 		Ref:     matchingRef,

--- a/git/git.go
+++ b/git/git.go
@@ -361,15 +361,7 @@ func NearestTag(repo *gogit.Repository, prefix string) (SemverRef, error) {
 		}
 
 		err = tags.ForEach(func(ref *plumbing.Reference) error {
-			if head.Hash() == ref.Hash() {
-				tagName := ref.Name().Short()
-				if strings.HasPrefix(tagName, prefix) {
-					nearestTag = tagName
-					matchingRef = ref
-					return storer.ErrStop
-				}
-			}
-			if ref.Hash() == commit.Hash {
+			if head.Hash() == ref.Hash() || ref.Hash() == commit.Hash {
 				tagName := ref.Name().Short()
 				if strings.HasPrefix(tagName, prefix) {
 					nearestTag = tagName

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -278,7 +278,7 @@ func TestCurrentVersionTagOnTheHead(t *testing.T) {
 			err := CreateTag(r.Repo, "0.0.1", prefix, false)
 			assert.Nil(t, err)
 
-			cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+			cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 			assert.Nil(t, err)
 			assert.Equal(t, NewVersionT(t, "0.0.1").String(), cr.Version.String())
 		})
@@ -297,7 +297,7 @@ func TestCurrentVersionNoTagOnTheHead(t *testing.T) {
 			r.DoCommit("bar")
 			cr, err := CurrentVersion(r.Repo, prefix, func(version *semver.Version) (semver.Version, error) {
 				return version.IncMinor().SetPrerelease("SNAPSHOT")
-			}, GetOptions{FirstTagEncountered: false})
+			}, GetOptions{NearestRelease: false})
 			assert.Nil(t, err)
 			assert.Equal(t, SemverRef{Ref: r.Head(), Version: NewVersionT(t, "0.1.0-SNAPSHOT")}, cr)
 		})
@@ -309,7 +309,7 @@ func TestCurrentVersionNoHead(t *testing.T) {
 	for _, prefix := range prefixes {
 		t.Run(prefix, func(t *testing.T) {
 			r := NewEmptyTestRepo(t)
-			_, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+			_, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 			assert.ErrorIs(t, err, plumbing.ErrReferenceNotFound)
 		})
 	}
@@ -320,7 +320,7 @@ func TestCurrentVersionNoTag(t *testing.T) {
 	for _, prefix := range prefixes {
 		t.Run(prefix, func(t *testing.T) {
 			r := NewTestRepo(t)
-			_, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+			_, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 			assert.ErrorIs(t, err, ErrNoTagFound)
 		})
 	}
@@ -340,7 +340,7 @@ func TestCurrentVersionWithCheckoutOlderRelease(t *testing.T) {
 			assert.Nil(t, err)
 
 			{
-				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "0.0.2"), cr.Version)
 			}
@@ -351,7 +351,7 @@ func TestCurrentVersionWithCheckoutOlderRelease(t *testing.T) {
 			assert.Nil(t, err)
 
 			{
-				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, checkoutHash, cr.Ref.Hash())
 				assert.Equal(t, NewVersionT(t, "0.0.1"), cr.Version)
@@ -375,7 +375,7 @@ func TestCurrentVersionWithCheckoutNewBranchWithUntaggedCommit(t *testing.T) {
 
 			// Validate
 			{
-				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "0.2.0"), cr.Version)
 			}
@@ -386,7 +386,7 @@ func TestCurrentVersionWithCheckoutNewBranchWithUntaggedCommit(t *testing.T) {
 
 			// Validate
 			{
-				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "0.3.0"), cr.Version)
 			}
@@ -410,7 +410,7 @@ func TestCurrentVersionWithCheckoutNewBranchWithUntaggedCommit(t *testing.T) {
 			// Assert current version with untagged commit
 			cr, err := CurrentVersion(r.Repo, prefix, func(version *semver.Version) (semver.Version, error) {
 				return version.IncMinor().SetPrerelease("SNAPSHOT")
-			}, GetOptions{FirstTagEncountered: true})
+			}, GetOptions{NearestRelease: true})
 			assert.NoError(t, err)
 			assert.Equal(t, newBranchHead, cr.Ref.Hash())
 			assert.Equal(t, NewVersionT(t, "0.2.0-SNAPSHOT"), cr.Version)
@@ -438,7 +438,7 @@ func TestCurrentVersionWithAnnotatedTags(t *testing.T) {
 			assert.Nil(t, err)
 
 			{
-				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, NewVersionT(t, "0.0.2"), cr.Version)
 			}
@@ -449,7 +449,7 @@ func TestCurrentVersionWithAnnotatedTags(t *testing.T) {
 			assert.Nil(t, err)
 
 			{
-				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{FirstTagEncountered: false})
+				cr, err := CurrentVersion(r.Repo, prefix, dontNeedPreRelease, GetOptions{NearestRelease: false})
 				assert.Nil(t, err)
 				assert.Equal(t, checkoutHash, cr.Ref.Hash())
 				assert.Equal(t, NewVersionT(t, "0.0.1"), cr.Version)
@@ -487,7 +487,7 @@ func TestCurrentVersionNoTagOnTheHeadInvalidPrerelease(t *testing.T) {
 				assert.Nil(t, err)
 
 				r.DoCommit("bar")
-				_, err = CurrentVersion(r.Repo, prefix, preRelease.fn, GetOptions{FirstTagEncountered: false})
+				_, err = CurrentVersion(r.Repo, prefix, preRelease.fn, GetOptions{NearestRelease: false})
 				assert.Regexp(t, preRelease.error, err)
 			})
 		}


### PR DESCRIPTION
Following up on the issue https://github.com/sky-uk/vergo/issues/23

Summary

This pull request introduces a new option to the Vergo tool, allowing it to determine the current version by traversing the commit history from the current commit and finding the first tag with a matching prefix. This new feature is implemented by modifying the CurrentVersion and Bump functions to use the GetFirstMatchingTag function instead of the LatestRef function.

Changes

- Added an option to enable the new feature that starts from the current commit and finds the first matching tag.
- Integrated the new feature option, incorporating the axion default behavior in the CurrentVersion function.
- Integrated the new feature option, incorporating the axion default behavior in the Bump function.
- Added unit tests


Notes:

1. This PR requires additional tests to be applied with and without the new option to ensure robustness. This is just a starting point.

2. The new feature replaces the use of `LatestRef` with `GetFirstMatchingTag` in `bump.go` and `git.go`.
Further evaluation is needed to determine if this change should also be applied to the push command and the get command for `latest-release`.

4. `TestBumpWithAnnotatedTags` should be removed since `CreateTagWithMessage` is not used by vergo.